### PR TITLE
Fix header file reference

### DIFF
--- a/Sources/ZoomImageViewer/ZoomImageViewRepresentable.swift
+++ b/Sources/ZoomImageViewer/ZoomImageViewRepresentable.swift
@@ -1,5 +1,5 @@
 //
-//  ImageZoomView.swift
+//  ZoomImageViewRepresentable.swift
 //  ZoomImageViewer
 //
 //  Created by Ryan Lintott on 2020-09-20.


### PR DESCRIPTION
## Summary
- correct file name in `ZoomImageViewRepresentable.swift`

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68506f1f9300832e8f848f9d802d07a4